### PR TITLE
Feature: Transform GeometryItem to Shape

### DIFF
--- a/src/main/java/com/treasure/hunt/jts/Circle.java
+++ b/src/main/java/com/treasure/hunt/jts/Circle.java
@@ -1,4 +1,4 @@
-package com.treasure.hunt.ui.jts;
+package com.treasure.hunt.jts;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -6,6 +6,11 @@ import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.util.GeometricShapeFactory;
 
+/**
+ * Adding a Geometry based Circle to the jts Geometry suite.
+ *
+ * @see org.locationtech.jts.geom.Geometry
+ */
 public class Circle extends Polygon {
     double radius;
 
@@ -20,7 +25,7 @@ public class Circle extends Polygon {
     }
 
     public Circle(Coordinate coordinate, double radius, GeometryFactory geometryFactory) {
-        this(coordinate, radius, 32, geometryFactory);
+        this(coordinate, radius, 64, geometryFactory);
     }
 
     public static Circle UnitCircle(Coordinate coordinate, GeometryFactory geometryFactory) {

--- a/src/main/java/com/treasure/hunt/strategy/geom/GeometryItem.java
+++ b/src/main/java/com/treasure/hunt/strategy/geom/GeometryItem.java
@@ -1,5 +1,7 @@
 package com.treasure.hunt.strategy.geom;
 
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import lombok.Value;
 import org.locationtech.jts.geom.Geometry;
 
@@ -8,8 +10,16 @@ import org.locationtech.jts.geom.Geometry;
  *
  * @see GeometryType for further information about how to classifiy a geometry item.
  */
+
+@AllArgsConstructor
 @Value
 public class GeometryItem<T extends Geometry> {
-    T object;
+    @NonNull T object;
     GeometryType type;
+
+
+    public GeometryItem(@NonNull T object) {
+        this.object = object;
+        this.type = new GeometryType();
+    }
 }

--- a/src/main/java/com/treasure/hunt/strategy/geom/GeometryType.java
+++ b/src/main/java/com/treasure/hunt/strategy/geom/GeometryType.java
@@ -2,13 +2,31 @@ package com.treasure.hunt.strategy.geom;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.awt.*;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class GeometryType {
-    Color color;
-    boolean visibleByDefault = false;
+    boolean visibleByDefault = true;
+    Color lineColor = Color.black;
+    Color fillColor = Color.black;
+    boolean filled = false;
     String displayText = "";
+
+
+    public GeometryType(boolean visibleByDefault, Color lineColor, String displayText) {
+        this(visibleByDefault, lineColor, Color.black, false, displayText);
+    }
+
+    public GeometryType(boolean visibleByDefault, Color lineColor) {
+        this(visibleByDefault, lineColor, "");
+    }
+
+    public GeometryType(boolean visibleByDefault, Color lineColor, Color fillColor) {
+        this(visibleByDefault, lineColor, fillColor, true, "");
+    }
+
 }

--- a/src/main/java/com/treasure/hunt/ui/jts/Circle.java
+++ b/src/main/java/com/treasure/hunt/ui/jts/Circle.java
@@ -1,0 +1,29 @@
+package com.treasure.hunt.ui.jts;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.util.GeometricShapeFactory;
+
+public class Circle extends Polygon {
+    double radius;
+
+    public Circle(Coordinate coordinate, double radius, int numOfPoints, GeometryFactory geometryFactory) {
+        super(null, null, geometryFactory);
+        GeometricShapeFactory geometricShapeFactory = new GeometricShapeFactory(geometryFactory);
+        geometricShapeFactory.setNumPoints(numOfPoints);
+        geometricShapeFactory.setCentre(coordinate);
+        geometricShapeFactory.setSize(radius * 2);
+        Polygon circle = geometricShapeFactory.createCircle();
+        this.shell = (LinearRing) circle.getExteriorRing();
+    }
+
+    public Circle(Coordinate coordinate, double radius, GeometryFactory geometryFactory) {
+        this(coordinate, radius, 32, geometryFactory);
+    }
+
+    public static Circle UnitCircle(Coordinate coordinate, GeometryFactory geometryFactory) {
+        return new Circle(coordinate, 1.0, geometryFactory);
+    }
+}

--- a/src/main/java/com/treasure/hunt/ui/swing/GeometryPanel.java
+++ b/src/main/java/com/treasure/hunt/ui/swing/GeometryPanel.java
@@ -1,0 +1,49 @@
+package com.treasure.hunt.ui.swing;
+
+import com.treasure.hunt.ui.jts.Circle;
+import org.locationtech.jts.awt.ShapeWriter;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.util.GeometricShapeFactory;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+
+public class GeometryPanel extends JPanel {
+    public GeometryPanel() {
+        super();
+    }
+
+    public void paint(Graphics graphics) {
+        Graphics2D graphics2D = (Graphics2D) graphics;
+        GeometryFactory geometryFactory = new GeometryFactory();
+        AffineTransform affineTransform = new AffineTransform();
+
+        Circle c1 = new Circle(new Coordinate(100, 100), 50, geometryFactory);
+        Circle c2 = new Circle(new Coordinate(150, 100), 50, geometryFactory);
+        Polygon intersection = (Polygon) c1.intersection(c2);
+
+        AffineTransformation affineTransformation = new AffineTransformation().translate(0.0, 20.0);
+
+        intersection = (Polygon) affineTransformation.transform(intersection);
+
+        drawShape(graphics2D, new Geometry[]{c1, c2, intersection}, geometryFactory);
+    }
+
+    public void drawShape(Graphics2D graphics2D, Geometry[] geometries, GeometryFactory geometryFactory) {
+        for (Geometry geometry : geometries)
+            drawShape(graphics2D, geometry, geometryFactory);
+    }
+
+    public void drawShape(Graphics2D graphics2D, Geometry geometry, GeometryFactory geometryFactory) {
+        GeometricShapeFactory geometricShapeFactory = new GeometricShapeFactory(geometryFactory);
+        ShapeWriter shapeWriter = new ShapeWriter();
+        graphics2D.setColor(new Color(0xFF3D27));
+        graphics2D.draw(shapeWriter.toShape(geometry));
+    }
+
+}

--- a/src/main/java/com/treasure/hunt/ui/swing/GeometryPanel.java
+++ b/src/main/java/com/treasure/hunt/ui/swing/GeometryPanel.java
@@ -1,49 +1,55 @@
 package com.treasure.hunt.ui.swing;
 
-import com.treasure.hunt.ui.jts.Circle;
+import com.treasure.hunt.strategy.geom.GeometryItem;
+import lombok.AllArgsConstructor;
+import org.locationtech.jts.awt.IdentityPointTransformation;
+import org.locationtech.jts.awt.PointTransformation;
 import org.locationtech.jts.awt.ShapeWriter;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Polygon;
-import org.locationtech.jts.geom.util.AffineTransformation;
-import org.locationtech.jts.util.GeometricShapeFactory;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.geom.AffineTransform;
 
+@AllArgsConstructor
 public class GeometryPanel extends JPanel {
-    public GeometryPanel() {
-        super();
+
+    private PointTransformation pointTransformation;
+
+    GeometryPanel() {
+        pointTransformation = new IdentityPointTransformation();
     }
 
     public void paint(Graphics graphics) {
         Graphics2D graphics2D = (Graphics2D) graphics;
-        GeometryFactory geometryFactory = new GeometryFactory();
-        AffineTransform affineTransform = new AffineTransform();
 
-        Circle c1 = new Circle(new Coordinate(100, 100), 50, geometryFactory);
-        Circle c2 = new Circle(new Coordinate(150, 100), 50, geometryFactory);
-        Polygon intersection = (Polygon) c1.intersection(c2);
+        RenderingHints renderingHints = new RenderingHints(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
-        AffineTransformation affineTransformation = new AffineTransformation().translate(0.0, 20.0);
+        graphics2D.addRenderingHints(renderingHints);
 
-        intersection = (Polygon) affineTransformation.transform(intersection);
-
-        drawShape(graphics2D, new Geometry[]{c1, c2, intersection}, geometryFactory);
+        drawGeometryItems(graphics2D, SwingTest.exampleGeometryItems());
     }
 
-    public void drawShape(Graphics2D graphics2D, Geometry[] geometries, GeometryFactory geometryFactory) {
-        for (Geometry geometry : geometries)
-            drawShape(graphics2D, geometry, geometryFactory);
+
+    private void drawGeometryItems(Graphics2D graphics2D, GeometryItem[] geometryItems) {
+        for (GeometryItem geometryItem : geometryItems)
+            drawGeometryItem(graphics2D, geometryItem);
     }
 
-    public void drawShape(Graphics2D graphics2D, Geometry geometry, GeometryFactory geometryFactory) {
-        GeometricShapeFactory geometricShapeFactory = new GeometricShapeFactory(geometryFactory);
-        ShapeWriter shapeWriter = new ShapeWriter();
-        graphics2D.setColor(new Color(0xFF3D27));
-        graphics2D.draw(shapeWriter.toShape(geometry));
+    private void drawGeometryItem(Graphics2D graphics2D, GeometryItem geometryItem) {
+        if (!geometryItem.getType().isVisibleByDefault())
+            return;
+
+        ShapeWriter shapeWriter = new ShapeWriter(pointTransformation);
+
+
+        Shape shape = shapeWriter.toShape(geometryItem.getObject());
+
+        if (geometryItem.getType().isFilled()) {
+            graphics2D.setColor(geometryItem.getType().getFillColor());
+            graphics2D.fill(shape);
+        }
+
+        graphics2D.setColor(geometryItem.getType().getLineColor());
+        graphics2D.draw(shape);
     }
 
 }

--- a/src/main/java/com/treasure/hunt/ui/swing/SwingTest.java
+++ b/src/main/java/com/treasure/hunt/ui/swing/SwingTest.java
@@ -1,12 +1,12 @@
 package com.treasure.hunt.ui.swing;
 
-import com.treasure.hunt.ui.jts.Circle;
-import org.locationtech.jts.awt.ShapeWriter;
-import org.locationtech.jts.geom.Point;
+import com.treasure.hunt.jts.Circle;
+import com.treasure.hunt.strategy.geom.GeometryItem;
+import com.treasure.hunt.strategy.geom.GeometryType;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
-import org.locationtech.jts.geom.*;
-import org.locationtech.jts.geom.impl.CoordinateArraySequence;
-import org.locationtech.jts.util.GeometricShapeFactory;
+import org.locationtech.jts.geom.util.AffineTransformation;
 
 import javax.swing.*;
 import javax.swing.plaf.metal.MetalLookAndFeel;
@@ -33,8 +33,31 @@ public class SwingTest extends JPanel {
         SwingUtilities.updateComponentTreeUI(frame);
     }
 
+    public static GeometryItem[] exampleGeometryItems() {
+        GeometryFactory geometryFactory = new GeometryFactory();
+
+        Circle c1 = new Circle(new Coordinate(100, 100), 50, geometryFactory);
+        Circle c2 = new Circle(new Coordinate(150, 100), 50, geometryFactory);
+        Polygon intersection = (Polygon) c1.intersection(c2);
+
+        AffineTransformation affineTransformation = new AffineTransformation().translate(0.0, 20.0);
+
+        intersection = (Polygon) affineTransformation.transform(intersection);
+
+        Polygon c3 = (Polygon) affineTransformation.transform(c1);
+
+        GeometryType intersectionType = new GeometryType(true, Color.red, Color.yellow, true, "");
+
+        return new GeometryItem[]{
+                new GeometryItem<>(c1, new GeometryType(true, Color.green)),
+                new GeometryItem<>(c2, new GeometryType(true, Color.blue)),
+                new GeometryItem<>(c3, intersectionType),
+                new GeometryItem<>(intersection, intersectionType),
+        };
+    }
+
     public void paint(Graphics graphics) {
-        Graphics2D graphics2D = (Graphics2D) graphics;
+        /*Graphics2D graphics2D = (Graphics2D) graphics;
         ShapeWriter shapeWriter = new ShapeWriter();
         GeometryFactory geometryFactory = new GeometryFactory();
         GeometricShapeFactory geometricShapeFactory = new GeometricShapeFactory();
@@ -59,7 +82,7 @@ public class SwingTest extends JPanel {
         graphics2D.draw(c_point);
         graphics2D.draw(c_triangle);
 
-        /*geometricShapeFactory.setNumPoints(12);
+        geometricShapeFactory.setNumPoints(12);
         geometricShapeFactory.setCentre(new Coordinate(120, 120));
         geometricShapeFactory.setSize(40);
 
@@ -67,16 +90,12 @@ public class SwingTest extends JPanel {
 
         Shape c_circle = shapeWriter.toShape(circle);
 
-        graphics2D.draw(c_circle);*/
+        graphics2D.draw(c_circle);
 
         Circle circle = new Circle(new Coordinate(120, 120), 10, geometryFactory);
 
         Shape new_circle = shapeWriter.toShape(circle);
 
-        graphics2D.draw(new_circle);
-    }
-
-    public void drawGeometry(Graphics2D graphics2D, Geometry geometry) {
-
+        graphics2D.draw(new_circle);*/
     }
 }

--- a/src/main/java/com/treasure/hunt/ui/swing/SwingTest.java
+++ b/src/main/java/com/treasure/hunt/ui/swing/SwingTest.java
@@ -1,0 +1,82 @@
+package com.treasure.hunt.ui.swing;
+
+import com.treasure.hunt.ui.jts.Circle;
+import org.locationtech.jts.awt.ShapeWriter;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
+import org.locationtech.jts.util.GeometricShapeFactory;
+
+import javax.swing.*;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import java.awt.*;
+
+public class SwingTest extends JPanel {
+
+    public static void main(String[] args) {
+        JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setSize(400, 400);
+        frame.setVisible(true);
+
+        GeometryPanel geometryPanel = new GeometryPanel();
+        frame.setContentPane(geometryPanel);
+
+        MetalLookAndFeel.setCurrentTheme(new TreasureHuntTheme());
+        try {
+            UIManager.setLookAndFeel(new MetalLookAndFeel());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        SwingUtilities.updateComponentTreeUI(frame);
+    }
+
+    public void paint(Graphics graphics) {
+        Graphics2D graphics2D = (Graphics2D) graphics;
+        ShapeWriter shapeWriter = new ShapeWriter();
+        GeometryFactory geometryFactory = new GeometryFactory();
+        GeometricShapeFactory geometricShapeFactory = new GeometricShapeFactory();
+
+        Coordinate[] list = {new Coordinate(100, 100)};
+        Point point = new org.locationtech.jts.geom.Point(new CoordinateArraySequence(list), geometryFactory);
+        Coordinate[] t_coord = {
+                new Coordinate(30, 30),
+                new Coordinate(50, 50),
+                new Coordinate(10, 50),
+                new Coordinate(30, 30)
+        };
+        LineString ls = geometryFactory.createLineString(new Coordinate[]{new Coordinate(20, 20), new Coordinate(200, 20)});
+
+        Polygon triangle = geometryFactory.createPolygon(new CoordinateArraySequence(t_coord));
+
+        Shape shape = shapeWriter.toShape(ls);
+        Shape c_point = shapeWriter.toShape(point);
+        Shape c_triangle = shapeWriter.toShape(triangle);
+
+        graphics2D.draw(shape);
+        graphics2D.draw(c_point);
+        graphics2D.draw(c_triangle);
+
+        /*geometricShapeFactory.setNumPoints(12);
+        geometricShapeFactory.setCentre(new Coordinate(120, 120));
+        geometricShapeFactory.setSize(40);
+
+        Geometry circle = geometricShapeFactory.createCircle();
+
+        Shape c_circle = shapeWriter.toShape(circle);
+
+        graphics2D.draw(c_circle);*/
+
+        Circle circle = new Circle(new Coordinate(120, 120), 10, geometryFactory);
+
+        Shape new_circle = shapeWriter.toShape(circle);
+
+        graphics2D.draw(new_circle);
+    }
+
+    public void drawGeometry(Graphics2D graphics2D, Geometry geometry) {
+
+    }
+}


### PR DESCRIPTION
The `Geometry` hierarchy of jts didn't include a `Circle` subclass. So I added a corresponding subclass to `Polygon`.

I discovered in the middle of producing that rendering `Geometry` instances is not flexible enough. So instead of rendering a simple `Geometry` instance I refactored the whole process to work with the previously proposed `GeometryItem`.

The translation from `GeometryType` to Shapes, Colors and so on happens directly in the JPanel - maybe needs refactoring e.g. `GeometryItem.toShape()`